### PR TITLE
Add basic docker support for quicker adpotion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:6.9
+ENV NODE_ENV local
+ADD . /code
+WORKDIR /code
+RUN npm install
+CMD node_modules/babel-cli/bin/babel-node.js ./src/index.js

--- a/README.md
+++ b/README.md
@@ -22,3 +22,14 @@ In order for this application to work it assumes you have
 
 ####Contributing
 Please see the [Project](https://github.com/dvideby0/api-scaffold/projects/2) page for current tasks 
+
+## Docker Support
+Will build the required multi-container application that is needed to run the api.
+
+Make sure you have docker installed:
+- https://www.docker.com/products/docker
+
+Through your terminal run `docker-compose up`, in the root directory.
+
+If you need to make changes start with the `docker-compose.yml`, followed
+by the `Dockerfile`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '2'
+services:
+  mongo:
+    image: mongo:3.2
+  reddis:
+    image: redis:3.2
+  api:
+    build: .
+    depends_on:
+      - mongo
+      - reddis
+    links:
+      - mongo
+      - reddis
+    ports: 
+      - 8080:9000
+    volumes:
+      - .:/code
+    environment:
+      MONGO_URI: mongodb://mongo:27017
+      REDIS_SOCKETIO_HOST: reddis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,20 +2,20 @@ version: '2'
 services:
   mongo:
     image: mongo:3.2
-  reddis:
+  redis:
     image: redis:3.2
   api:
     build: .
     depends_on:
       - mongo
-      - reddis
+      - redis
     links:
       - mongo
-      - reddis
+      - redis
     ports: 
       - 8080:9000
     volumes:
       - .:/code
     environment:
       MONGO_URI: mongodb://mongo:27017
-      REDIS_SOCKETIO_HOST: reddis
+      REDIS_SOCKETIO_HOST: redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,10 @@ version: '2'
 services:
   mongo:
     image: mongo:3.2
+    # restart: always 
   redis:
     image: redis:3.2
+    # restart: always
   api:
     build: .
     depends_on:
@@ -19,3 +21,4 @@ services:
     environment:
       MONGO_URI: mongodb://mongo:27017
       REDIS_SOCKETIO_HOST: redis
+    # restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - mongo
       - redis
     ports: 
-      - 8080:9000
+      - 9000:9000
     volumes:
       - .:/code
     environment:


### PR DESCRIPTION
The ideas is that if someone downloads the repo, they could just spin up `docker-compose` and get started quickly with checking out the code base.  The docker support is enough to get the api started. 